### PR TITLE
Notifications Service: Update Java and NodeJS example dependencies

### DIFF
--- a/how-to/use-notifications-service/java-with-jwt/pom.xml
+++ b/how-to/use-notifications-service/java-with-jwt/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>co.openfin</groupId>
             <artifactId>java-cloud-notification-api</artifactId>
-            <version>0.0.4</version>
+            <version>8.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.cdimascio</groupId>

--- a/how-to/use-notifications-service/nodeJS-with-jwt/package.json
+++ b/how-to/use-notifications-service/nodeJS-with-jwt/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@openfin/cloud-notification-core-api": "^0.0.1-alpha.f995a04",
+    "@openfin/cloud-notification-core-api": "^0.0.1-alpha.c2ab1c3",
     "chalk": "^5.4.1",
     "dotenv-defaults": "^5.0.2",
     "jsonwebtoken": "^9.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@openfin/cloud-notification-core-api": "^0.0.1-alpha.f995a04",
+        "@openfin/cloud-notification-core-api": "^0.0.1-alpha.c2ab1c3",
         "chalk": "^5.4.1",
         "dotenv-defaults": "^5.0.2",
         "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
Due to errors found while testing the Java notification demo, the dependencies of both notification demos should be updated to the latest version.