### PR TITLE
[DEVOP-2359] Add GitHub Actions workflow for publishing HOWTOs

### DIFF
--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     name: Build and package HOWTOs
     runs-on: ubuntu-latest
-    env:
-      RELEASE_BRANCH_PREFIX: here/
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -44,28 +44,12 @@ jobs:
           PKG_HOWTOS_LOCATION: github
           PKG_HOWTOS_PATH: ${{ github.ref_name }}
 
-      - name: Package for publishing AWS S3 CDN
-        if: ${{ startsWith(github.ref_name, env.RELEASE_BRANCH_PREFIX) }}
-        run: npm run package
-        env:
-          PKG_HOWTOS_LOCATION: aws
-          PKG_HOWTOS_PATH: ${{ github.ref_name }}
-
       - name: Upload artifacts GitHub Pages
         uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
           name: workflow-howtos-github
           path: public-github/
-          retention-days: 1
-
-      - name: Upload artifacts AWS S3 CDN
-        if: ${{ startsWith(github.ref_name, env.RELEASE_BRANCH_PREFIX) }}
-        uses: actions/upload-artifact@v7
-        with:
-          if-no-files-found: error
-          name: workflow-howtos-aws
-          path: public-aws/
           retention-days: 1
 
   publish-gh:

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -59,9 +59,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
       - name: Download artifacts
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -59,6 +59,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      
       - name: Download artifacts
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -1,0 +1,93 @@
+name: Publish HOWTOs
+
+on:
+  push:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and package HOWTOs
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_BRANCH_PREFIX: here/
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          scope: '@openfin'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Package for publishing GitHub Pages
+        run: npm run package
+        env:
+          PKG_HOWTOS_LOCATION: github
+          PKG_HOWTOS_PATH: ${{ github.ref_name }}
+
+      - name: Package for publishing AWS S3 CDN
+        if: ${{ startsWith(github.ref_name, env.RELEASE_BRANCH_PREFIX) }}
+        run: npm run package
+        env:
+          PKG_HOWTOS_LOCATION: aws
+          PKG_HOWTOS_PATH: ${{ github.ref_name }}
+
+      - name: Upload artifacts GitHub Pages
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: error
+          name: workflow-howtos-github
+          path: public-github/
+          retention-days: 1
+
+      - name: Upload artifacts AWS S3 CDN
+        if: ${{ startsWith(github.ref_name, env.RELEASE_BRANCH_PREFIX) }}
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: error
+          name: workflow-howtos-aws
+          path: public-aws/
+          retention-days: 1
+
+  publish-gh:
+    name: Publish HOWTOs GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: workflow-howtos-github
+          path: public-github/
+
+      - name: Publish
+        uses: JamesIves/github-pages-deploy-action@v4.7.4
+        with:
+          branch: gh-pages
+          folder: public-github
+          target-folder: ${{ github.ref_name }}
+  

--- a/.github/workflows/publish-HOWTOs.yml
+++ b/.github/workflows/publish-HOWTOs.yml
@@ -2,6 +2,8 @@ name: Publish HOWTOs
 
 on:
   push:
+    branches-ignore:
+      - gh-pages
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Summary

Adds the initial Publish HOWTOs GitHub Actions workflow for building, packaging, and publishing HOWTO documentation, with branch-specific support for here/ and dev/ branches.

### Changes
- Adds a new Publish HOWTOs workflow triggered on push and workflow_dispatch.
- Configures concurrency to prevent overlapping publishes for the same ref.
- Uses Node 24 with npm dependency caching.
- Installs dependencies with npm ci.
- Builds the HOWTO packages using npm run build.
- Packages HOWTO output for GitHub Pages publishing.
- Supports branch-specific packaging for here/ and dev/ branches.
- Uploads generated HOWTO artifacts with short retention.
- Publishes the GitHub Pages artifact to the gh-pages branch under the current branch name.